### PR TITLE
Single page overflow fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,9 +51,9 @@
               </span>
             </section>
             <div class="guess-button-cont">
-              <button class="bold disabled" disabled id="submit-guess"> SUBMIT GUESS </button>
-              <button class="bold disabled" disabled> RESET GAME </button>
-              <button class="bold disabled" disabled> CLEAR FORM </button>
+              <button class="bold disabled" disabled id="submit-guess">SUBMIT&nbsp;GUESS</button>
+              <button class="bold disabled" disabled>RESET&nbsp;GAME</button>
+              <button class="bold disabled" disabled>CLEAR&nbsp;FORM</button>
             </div>
           </form>
         </section>

--- a/index.html
+++ b/index.html
@@ -51,9 +51,9 @@
               </span>
             </section>
             <div class="guess-button-cont">
-              <button class="bold disabled" disabled id="submit-guess">SUBMIT&nbsp;GUESS</button>
-              <button class="bold disabled" disabled>RESET&nbsp;GAME</button>
-              <button class="bold disabled" disabled>CLEAR&nbsp;FORM</button>
+              <button class="bold disabled" disabled id="submit-guess">SUBMIT GUESS</button>
+              <button class="bold disabled" disabled>RESET GAME</button>
+              <button class="bold disabled" disabled>CLEAR FORM</button>
             </div>
           </form>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -69,7 +69,7 @@ header {
   text-align: center;
   background-color: #404041;
   color: #fff;
-  padding: 2.5%;
+  padding: 1.5%;
 }
 
 button {
@@ -81,10 +81,14 @@ button {
 }
 
 header h1 {
-  font-size: 50px;
+  font-size: 40px;
   font-weight: 700;
   line-height: 1;
   padding-bottom: 5px;
+}
+
+header h3 {
+  font-size: 15px;
 }
 
 .header-ruler,
@@ -93,7 +97,7 @@ header h1 {
 }
 
 .header-ruler {
-  width: 60px;
+  width: 45px;
   margin: 5px 10px;
 }
 
@@ -109,9 +113,9 @@ arranged in order that they appear in the html
 
 .left-column {
   width: 50vw;
-  height: 100vh;
   background-color: #f7f7f7;
   padding: 0 2.5%;
+  padding-bottom: 2.5%;
  }
 
 .gameplay-cont {
@@ -219,7 +223,6 @@ End of Latest Guess Container
 
 .right-column {
   width: 50vw;
-  height: 100vh;
   background-color: #d0d2d3;
 }
 
@@ -234,9 +237,11 @@ End of Latest Guess Container
   padding:  5% 2.5%;
   box-shadow: 1px 1px 1px #e4e4e4;
   border-radius: 2px;
+  font-size: 12px;
 }
 
 .set-range h3 {
+  font-size: 16px;
   margin-bottom: 2%;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -234,7 +234,7 @@ End of Latest Guess Container
 .set-range {
   border: solid 0.5px #e4e4e4;
   margin-top: 5%;
-  padding:  5% 2.5%;
+  padding:  3% 2.5%;
   box-shadow: 1px 1px 1px #e4e4e4;
   border-radius: 2px;
   font-size: 12px;
@@ -242,7 +242,7 @@ End of Latest Guess Container
 
 .set-range h3 {
   font-size: 16px;
-  margin-bottom: 2%;
+  margin-bottom: 1%;
 }
 
 .set-range button {
@@ -256,6 +256,10 @@ End of Latest Guess Container
   display: inline-block;
   width: 35%;
   margin-right: 2.5%;
+}
+
+.set-range input {
+  margin-top: 2.5%;
 }
 
 .range-input label {

--- a/styles.css
+++ b/styles.css
@@ -167,11 +167,13 @@ arranged in order that they appear in the html
 
 .guess-button-cont {
   display: flex;
-  align-content: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .guess-button-cont button {
-  margin: 0px auto;
+  flex-grow: 1;
+  margin: 2.5%;
 }
 
 /*


### PR DESCRIPTION
I noticed that the left-side content was overflowing its column container after the final card was added. It turned out to be b/c of the height manually set in the left- and right-side columns. 

This PR:

- Fixes the overflow issue mentioned above
- Updates the set-range and header containers with global classes
- Addresses left-side button issue with text breaking on screen resize
- Adjusts global button responsiveness on mobile