### PR TITLE
Add game reset functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@ function activateClearFormButton () {
   }
 }
 
-function clearGuessFields () {
+function clearGuessFields() {
   guessForm.reset();
   disableGuessButtons();
   event.preventDefault();
@@ -120,6 +120,8 @@ function guessComparison (firstUserGuess, secondUserGuess, firstUserName, second
   } else if (firstGuess === randNumb) {
     firstGuessProximity = 'BOOM!'
     insertResultCard(firstUserName, secondUserName, firstUserName);
+    randNumb = generateRandomNumber();
+    guessCounter = 0;
   }
   if (secondGuess > randNumb) {
     secondGuessProximity = `that's too high`
@@ -128,6 +130,8 @@ function guessComparison (firstUserGuess, secondUserGuess, firstUserName, second
   } else if (secondGuess === randNumb) {
     secondGuessProximity = 'BOOM!'
     insertResultCard(firstUserName, secondUserName, secondUserName);
+    randNumb = generateRandomNumber();
+    guessCounter = 0;
   }
   insertGuessProximity(firstGuessProximity, secondGuessProximity);
 }


### PR DESCRIPTION
This PR:

- Adds variable resets to the guess comparison function, in order to reset the game once a player has won

Needs:

- Seems logical to assume that the name field shouldn't clear out on every guess, but should clear out once a player has won